### PR TITLE
Configurable node constraint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
   <parent>
-    <groupId>org.jvnet.hudson.plugins</groupId>
+    <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.377</version>
-    <relativePath>../pom.xml</relativePath>
+    <version>1.457</version>
   </parent>
   
+  <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>heavy-job</artifactId>
   <version>1.1-SNAPSHOT</version>
   <packaging>hpi</packaging>

--- a/src/main/resources/hudson/plugins/heavy_job/HeavyJobProperty/config.jelly
+++ b/src/main/resources/hudson/plugins/heavy_job/HeavyJobProperty/config.jelly
@@ -26,4 +26,7 @@ THE SOFTWARE.
   <f:entry title="${%Job Weight}" field="weight">
     <f:textbox default="1" />
   </f:entry>
+  <f:entry title="${%Executors must reside on the same node}" field="sameNode">
+     <f:checkbox default="true" />
+  </f:entry>
 </j:jelly>


### PR DESCRIPTION
Add an option to grab executors on different nodes. This is useful for jobs which need more than 1 slave. In our case we're using this to do distributed execution of unit tests in a large project. 
