### PR TITLE
All executor feature.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,10 +2,9 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jvnet.hudson.plugins</groupId>
+    <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.377</version>
-    <relativePath>../pom.xml</relativePath>
+    <version>1.457</version>
   </parent>
   
   <artifactId>heavy-job</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.457</version>
+    <version>1.516</version>
   </parent>
   
   <artifactId>heavy-job</artifactId>
@@ -60,6 +60,14 @@
             <url>http://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
+   <build>
+      <plugins>
+        <plugin>
+          <groupId>org.jenkins-ci.tools</groupId>
+          <artifactId>maven-hpi-plugin</artifactId>
+          </plugin>
+      </plugins>
+    </build>
 </project>  
   
 

--- a/src/main/java/hudson/plugins/heavy_job/HeavyJobProperty.java
+++ b/src/main/java/hudson/plugins/heavy_job/HeavyJobProperty.java
@@ -105,9 +105,7 @@ public class HeavyJobProperty extends JobProperty<AbstractProject<?,?>> {
    * @return Returns the number of executors available on the node.
    */
   private int getExecutors() {
-    final Computer computer = Computer.currentComputer();
-    final Node node = computer.getNode();
-    return node.getNumExecutors();
+    return Computer.currentComputer().getNumExecutors();
   }
 
   @Extension

--- a/src/main/java/hudson/plugins/heavy_job/HeavyJobProperty.java
+++ b/src/main/java/hudson/plugins/heavy_job/HeavyJobProperty.java
@@ -74,10 +74,7 @@ public class HeavyJobProperty extends JobProperty<AbstractProject<?, ?>> {
 		// Only if allExecutors is checked will we attempt to set the weight.
 		// Otherwise, we just use weight that was passed in.
 		if (allExecutorsEnabled) {
-			LOGGER.fine("Got allExecutorsEnabled setting weight");
 			this.weight = getExecutors();
-			LOGGER.fine("Job is: " + this.owner.getDisplayName());
-			LOGGER.fine("Weight is: " + this.weight);
 		}
 		for (int i = 1; i < weight; i++) {
 			r.add(new AbstractSubTask() {
@@ -134,31 +131,18 @@ public class HeavyJobProperty extends JobProperty<AbstractProject<?, ?>> {
 		if (label != null) {
 			if (label.isSelfLabel()
 					&& !label.getName().equalsIgnoreCase("master")) {
-				LOGGER.fine("Label: " + label.toString());
 				node = Jenkins.getInstance().getNode(label.getName());
-				if (node != null) {
-					LOGGER.fine("Number of executors: "
-							+ node.getNumExecutors());
-					LOGGER.fine("Name of node: " + node.getNodeName());
-					LOGGER.fine("Name of job: "
-							+ HeavyJobProperty.this.owner.getDisplayName());
-				} else {
-					LOGGER.fine("Node was null, returning weight.");
+				if (node == null) {
+					LOGGER.fine("Node was null, returning set weight.");
 					return this.weight;
 				}
 			} else if (label.getName().equalsIgnoreCase("master")) {
-				LOGGER.fine("Number of executors: "
-						+ Jenkins.getInstance().getNumExecutors());
-				LOGGER.fine("Name of node: "
-						+ Jenkins.getInstance().getDisplayName());
-				LOGGER.fine("Name of job: "
-						+ HeavyJobProperty.this.owner.getDisplayName());
 				return Jenkins.getInstance().getNumExecutors();
 			} else {
 				return this.weight;
 			}
 		} else {
-			LOGGER.fine("Label was null, returning weight.");
+			LOGGER.fine("Label was null, returning set weight.");
 			return this.weight;
 		}
 

--- a/src/main/java/hudson/plugins/heavy_job/HeavyJobProperty.java
+++ b/src/main/java/hudson/plugins/heavy_job/HeavyJobProperty.java
@@ -137,5 +137,10 @@ public class HeavyJobProperty extends JobProperty<AbstractProject<?,?>> {
     public void run() {
       // nothing. we just waste time
     }
+
+	@Override
+	public long getEstimatedDuration() {
+		return executor.getCurrentWorkUnit().context.getPrimaryWorkUnit().getExecutable().getEstimatedDuration();
+	}
   }
 }

--- a/src/main/java/hudson/plugins/heavy_job/HeavyJobProperty.java
+++ b/src/main/java/hudson/plugins/heavy_job/HeavyJobProperty.java
@@ -34,6 +34,7 @@ import hudson.model.Node;
 import hudson.model.Queue.Executable;
 import hudson.model.Queue.Task;
 import hudson.model.queue.AbstractSubTask;
+import hudson.model.queue.Executables;
 import hudson.model.queue.SubTask;
 
 import java.io.IOException;
@@ -138,7 +139,9 @@ public class HeavyJobProperty extends JobProperty<AbstractProject<?,?>> {
 
 	@Override
 	public long getEstimatedDuration() {
-		return executor.getCurrentWorkUnit().context.getPrimaryWorkUnit().getExecutable().getEstimatedDuration();
+		return 0;
 	}
+
+
   }
 }

--- a/src/main/java/hudson/plugins/heavy_job/HeavyJobProperty.java
+++ b/src/main/java/hudson/plugins/heavy_job/HeavyJobProperty.java
@@ -28,120 +28,165 @@ import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
-import hudson.model.Computer;
 import hudson.model.Executor;
+import hudson.model.Label;
 import hudson.model.Node;
 import hudson.model.Queue.Executable;
 import hudson.model.Queue.Task;
 import hudson.model.queue.AbstractSubTask;
-import hudson.model.queue.Executables;
 import hudson.model.queue.SubTask;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
+
+import jenkins.model.Jenkins;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * Keeps track of the number of executors that need to be consumed for this job.
- *
+ * 
  * @author Kohsuke Kawaguchi
  */
-public class HeavyJobProperty extends JobProperty<AbstractProject<?,?>> {
-  public int weight;
-  public final boolean allExecutorsEnabled;
+public class HeavyJobProperty extends JobProperty<AbstractProject<?, ?>> {
+	public int weight;
+	public final boolean allExecutorsEnabled;
 
-  @DataBoundConstructor
-  public HeavyJobProperty(final int weight, final boolean allExecutorsEnabled) {
-    this.weight = weight;
-    this.allExecutorsEnabled = allExecutorsEnabled;
-  }
+	private static final Logger LOGGER = Logger
+			.getLogger(HeavyJobProperty.class.getName());
 
-  @Override
-  public List<SubTask> getSubTasks() {
-    final List<SubTask> r = new ArrayList<SubTask>();
-
-    // Store the weight before setting it to the maximum. So I can reset it
-    // after.
-    final int storedWeight = this.weight;
-    if (allExecutorsEnabled) {
-      this.weight = getExecutors();
-    }
-    for (int i=1; i< weight; i++) {
-      r.add(new AbstractSubTask() {
-        public Executable createExecutable() throws IOException {
-          return new ExecutableImpl(this);
-        }
-
-        @Override
-        public Object getSameNodeConstraint() {
-          // must occupy the same node as the project itself
-          return getProject();
-        }
-
-        @Override
-        public long getEstimatedDuration() {
-          return getProject().getEstimatedDuration();
-        }
-
-        public Task getOwnerTask() {
-          return getProject();
-        }
-
-        public String getDisplayName() {
-          return Messages.HeavyJobProperty_SubTaskDisplayName(getProject().getDisplayName());
-        }
-
-        private AbstractProject<?, ?> getProject() {
-          return HeavyJobProperty.this.owner;
-        }
-      });
-    }
-    this.weight = storedWeight;
-    return r;
-  }
-
-  /**
-   * @return Returns the number of executors available on the node.
-   */
-  private int getExecutors() {
-    return Computer.currentComputer().getNumExecutors();
-  }
-
-  @Extension
-  public static class DescriptorImpl extends JobPropertyDescriptor {
-    @Override
-    public String getDisplayName() {
-      return Messages.HeavyJobProperty_DisplayName();
-    }
-  }
-
-  public static class ExecutableImpl implements Executable {
-    private final SubTask parent;
-    private final Executor executor = Executor.currentExecutor();
-
-    private ExecutableImpl(final SubTask parent) {
-      this.parent = parent;
-    }
-
-    public SubTask getParent() {
-      return parent;
-    }
-
-    public AbstractBuild<?,?> getBuild() {
-      return (AbstractBuild<?,?>)executor.getCurrentWorkUnit().context.getPrimaryWorkUnit().getExecutable();
-    }
-
-    public void run() {
-      // nothing. we just waste time
-    }
-
-	@Override
-	public long getEstimatedDuration() {
-		return 0;
+	@DataBoundConstructor
+	public HeavyJobProperty(final int weight, final boolean allExecutorsEnabled) {
+		this.weight = weight;
+		this.allExecutorsEnabled = allExecutorsEnabled;
 	}
 
+	@Override
+	public List<SubTask> getSubTasks() {
+		final List<SubTask> r = new ArrayList<SubTask>();
 
-  }
+		// Store the weight before setting it to the maximum. So I can reset it
+		// after.
+		final int storedWeight = this.weight;
+
+		// Only if allExecutors is checked will we attempt to set the weight.
+		// Otherwise, we just use weight that was passed in.
+		if (allExecutorsEnabled) {
+			LOGGER.fine("Got allExecutorsEnabled setting weight");
+			this.weight = getExecutors();
+			LOGGER.fine("Job is: " + this.owner.getDisplayName());
+			LOGGER.fine("Weight is: " + this.weight);
+		}
+		for (int i = 1; i < weight; i++) {
+			r.add(new AbstractSubTask() {
+				public Executable createExecutable() throws IOException {
+					return new ExecutableImpl(this);
+				}
+
+				@Override
+				public Object getSameNodeConstraint() {
+					// must occupy the same node as the project itself
+					return getProject();
+				}
+
+				@Override
+				public long getEstimatedDuration() {
+					return getProject().getEstimatedDuration();
+				}
+
+				public Task getOwnerTask() {
+					return getProject();
+				}
+
+				public String getDisplayName() {
+					return Messages
+							.HeavyJobProperty_SubTaskDisplayName(getProject()
+									.getDisplayName());
+				}
+
+				private AbstractProject<?, ?> getProject() {
+					return HeavyJobProperty.this.owner;
+				}
+			});
+		}
+		this.weight = storedWeight;
+		return r;
+	}
+
+	/**
+	 * @return Returns the number of executors available on the node.
+	 */
+	private int getExecutors() {
+		Node node = null;
+
+		// Get the label. Have to get the QueueItem if the build goes to Queue.
+		Label label = (HeavyJobProperty.this.owner.getAssignedLabel() != null) ? HeavyJobProperty.this.owner
+				.getAssignedLabel() : HeavyJobProperty.this.owner
+				.getQueueItem().getAssignedLabel();
+
+		// Check to see it got the label object. Since we want to be certain we
+		// get the correct node, we check to make sure that the label is a self
+		// label. Also check if the label is master. When master we can't use
+		// node, so we get the Jenkins instance for master executor count. If
+		// it's not a self label or master, we default to the weight passed in.
+		if (label != null && label.isSelfLabel()
+				&& !label.getName().equalsIgnoreCase("master")) {
+			LOGGER.fine("Label: " + label.toString());
+			node = Jenkins.getInstance().getNode(label.getName());
+			LOGGER.fine("Number of executors: " + node.getNumExecutors());
+			LOGGER.fine("Name of node: " + node.getNodeName());
+			LOGGER.fine("Name of job: "
+					+ HeavyJobProperty.this.owner.getDisplayName());
+		} else if (label.getName().equalsIgnoreCase("master")) {
+			LOGGER.fine("Number of executors: "
+					+ Jenkins.getInstance().getNumExecutors());
+			LOGGER.fine("Name of node: "
+					+ Jenkins.getInstance().getDisplayName());
+			LOGGER.fine("Name of job: "
+					+ HeavyJobProperty.this.owner.getDisplayName());
+			return Jenkins.getInstance().getNumExecutors();
+		} else {
+			return this.weight;
+		}
+
+		return node.getNumExecutors();
+	}
+
+	@Extension
+	public static class DescriptorImpl extends JobPropertyDescriptor {
+		@Override
+		public String getDisplayName() {
+			return Messages.HeavyJobProperty_DisplayName();
+		}
+	}
+
+	public static class ExecutableImpl implements Executable {
+		private final SubTask parent;
+		private final Executor executor = Executor.currentExecutor();
+
+		private ExecutableImpl(final SubTask parent) {
+			this.parent = parent;
+		}
+
+		public SubTask getParent() {
+			return parent;
+		}
+
+		public AbstractBuild<?, ?> getBuild() {
+			return (AbstractBuild<?, ?>) executor.getCurrentWorkUnit().context
+					.getPrimaryWorkUnit().getExecutable();
+		}
+
+		public void run() {
+			// nothing. we just waste time
+		}
+
+		@Override
+		public long getEstimatedDuration() {
+			return parent.getEstimatedDuration();
+		}
+
+	}
 }

--- a/src/main/java/hudson/plugins/heavy_job/HeavyJobProperty.java
+++ b/src/main/java/hudson/plugins/heavy_job/HeavyJobProperty.java
@@ -24,20 +24,23 @@
 package hudson.plugins.heavy_job;
 
 import hudson.Extension;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.Executor;
 import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.Computer;
+import hudson.model.Executor;
+import hudson.model.Node;
 import hudson.model.Queue.Executable;
 import hudson.model.Queue.Task;
 import hudson.model.queue.AbstractSubTask;
 import hudson.model.queue.SubTask;
-import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
  * Keeps track of the number of executors that need to be consumed for this job.
@@ -45,74 +48,94 @@ import java.util.List;
  * @author Kohsuke Kawaguchi
  */
 public class HeavyJobProperty extends JobProperty<AbstractProject<?,?>> {
-    public final int weight;
+  public int weight;
+  public final boolean allExecutorsEnabled;
 
-    @DataBoundConstructor
-    public HeavyJobProperty(int weight) {
-        this.weight = weight;
+  @DataBoundConstructor
+  public HeavyJobProperty(final int weight, final boolean allExecutorsEnabled) {
+    this.weight = weight;
+    this.allExecutorsEnabled = allExecutorsEnabled;
+  }
+
+  @Override
+  public List<SubTask> getSubTasks() {
+    final List<SubTask> r = new ArrayList<SubTask>();
+
+    // Store the weight before setting it to the maximum. So I can reset it
+    // after.
+    final int storedWeight = this.weight;
+    if (allExecutorsEnabled) {
+      this.weight = getExecutors();
     }
+    for (int i=1; i< weight; i++) {
+      r.add(new AbstractSubTask() {
+        public Executable createExecutable() throws IOException {
+          return new ExecutableImpl(this);
+        }
 
-    @Override
-    public List<SubTask> getSubTasks() {
-        List<SubTask> r = new ArrayList<SubTask>();
-        for (int i=1; i< weight; i++)
-            r.add(new AbstractSubTask() {
-                public Executable createExecutable() throws IOException {
-                    return new ExecutableImpl(this);
-                }
-
-                @Override
-                public Object getSameNodeConstraint() {
-                    // must occupy the same node as the project itself
-                    return getProject();
-                }
-
-                @Override
-                public long getEstimatedDuration() {
-                    return getProject().getEstimatedDuration();
-                }
-
-                public Task getOwnerTask() {
-                    return getProject();
-                }
-
-                public String getDisplayName() {
-                    return Messages.HeavyJobProperty_SubTaskDisplayName(getProject().getDisplayName());
-                }
-
-                private AbstractProject<?, ?> getProject() {
-                    return HeavyJobProperty.this.owner;
-                }
-            });
-        return r;
-    }
-
-    @Extension
-    public static class DescriptorImpl extends JobPropertyDescriptor {
         @Override
+        public Object getSameNodeConstraint() {
+          // must occupy the same node as the project itself
+          return getProject();
+        }
+
+        @Override
+        public long getEstimatedDuration() {
+          return getProject().getEstimatedDuration();
+        }
+
+        public Task getOwnerTask() {
+          return getProject();
+        }
+
         public String getDisplayName() {
-            return Messages.HeavyJobProperty_DisplayName();
+          return Messages.HeavyJobProperty_SubTaskDisplayName(getProject().getDisplayName());
         }
+
+        private AbstractProject<?, ?> getProject() {
+          return HeavyJobProperty.this.owner;
+        }
+      });
+    }
+    this.weight = storedWeight;
+    return r;
+  }
+
+  /**
+   * @return Returns the number of executors available on the node.
+   */
+  private int getExecutors() {
+    final Computer computer = Computer.currentComputer();
+    final Node node = computer.getNode();
+    return node.getNumExecutors();
+  }
+
+  @Extension
+  public static class DescriptorImpl extends JobPropertyDescriptor {
+    @Override
+    public String getDisplayName() {
+      return Messages.HeavyJobProperty_DisplayName();
+    }
+  }
+
+  public static class ExecutableImpl implements Executable {
+    private final SubTask parent;
+    private final Executor executor = Executor.currentExecutor();
+
+    private ExecutableImpl(final SubTask parent) {
+      this.parent = parent;
     }
 
-    public static class ExecutableImpl implements Executable {
-        private final SubTask parent;
-        private final Executor executor = Executor.currentExecutor();
-
-        private ExecutableImpl(SubTask parent) {
-            this.parent = parent;
-        }
-
-        public SubTask getParent() {
-            return parent;
-        }
-
-        public AbstractBuild<?,?> getBuild() {
-            return (AbstractBuild<?,?>)executor.getCurrentWorkUnit().context.getPrimaryWorkUnit().getExecutable();
-        }
-
-        public void run() {
-            // nothing. we just waste time
-        }
+    public SubTask getParent() {
+      return parent;
     }
+
+    public AbstractBuild<?,?> getBuild() {
+      return (AbstractBuild<?,?>)executor.getCurrentWorkUnit().context.getPrimaryWorkUnit().getExecutable();
+    }
+
+    public void run() {
+      // nothing. we just waste time
+    }
+  }
 }

--- a/src/main/java/hudson/plugins/heavy_job/HeavyJobProperty.java
+++ b/src/main/java/hudson/plugins/heavy_job/HeavyJobProperty.java
@@ -131,23 +131,34 @@ public class HeavyJobProperty extends JobProperty<AbstractProject<?, ?>> {
 		// label. Also check if the label is master. When master we can't use
 		// node, so we get the Jenkins instance for master executor count. If
 		// it's not a self label or master, we default to the weight passed in.
-		if (label != null && label.isSelfLabel()
-				&& !label.getName().equalsIgnoreCase("master")) {
-			LOGGER.fine("Label: " + label.toString());
-			node = Jenkins.getInstance().getNode(label.getName());
-			LOGGER.fine("Number of executors: " + node.getNumExecutors());
-			LOGGER.fine("Name of node: " + node.getNodeName());
-			LOGGER.fine("Name of job: "
-					+ HeavyJobProperty.this.owner.getDisplayName());
-		} else if (label.getName().equalsIgnoreCase("master")) {
-			LOGGER.fine("Number of executors: "
-					+ Jenkins.getInstance().getNumExecutors());
-			LOGGER.fine("Name of node: "
-					+ Jenkins.getInstance().getDisplayName());
-			LOGGER.fine("Name of job: "
-					+ HeavyJobProperty.this.owner.getDisplayName());
-			return Jenkins.getInstance().getNumExecutors();
+		if (label != null) {
+			if (label.isSelfLabel()
+					&& !label.getName().equalsIgnoreCase("master")) {
+				LOGGER.fine("Label: " + label.toString());
+				node = Jenkins.getInstance().getNode(label.getName());
+				if (node != null) {
+					LOGGER.fine("Number of executors: "
+							+ node.getNumExecutors());
+					LOGGER.fine("Name of node: " + node.getNodeName());
+					LOGGER.fine("Name of job: "
+							+ HeavyJobProperty.this.owner.getDisplayName());
+				} else {
+					LOGGER.fine("Node was null, returning weight.");
+					return this.weight;
+				}
+			} else if (label.getName().equalsIgnoreCase("master")) {
+				LOGGER.fine("Number of executors: "
+						+ Jenkins.getInstance().getNumExecutors());
+				LOGGER.fine("Name of node: "
+						+ Jenkins.getInstance().getDisplayName());
+				LOGGER.fine("Name of job: "
+						+ HeavyJobProperty.this.owner.getDisplayName());
+				return Jenkins.getInstance().getNumExecutors();
+			} else {
+				return this.weight;
+			}
 		} else {
+			LOGGER.fine("Label was null, returning weight.");
 			return this.weight;
 		}
 

--- a/src/main/resources/hudson/plugins/heavy_job/HeavyJobProperty/config.jelly
+++ b/src/main/resources/hudson/plugins/heavy_job/HeavyJobProperty/config.jelly
@@ -26,4 +26,7 @@ THE SOFTWARE.
   <f:entry title="${%Job Weight}" field="weight">
     <f:textbox default="1" />
   </f:entry>
+  <f:entry title="${%Use All Executors}" field="allExecutorsEnabled">
+    <f:checkbox/>
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/heavy_job/HeavyJobProperty/config.jelly
+++ b/src/main/resources/hudson/plugins/heavy_job/HeavyJobProperty/config.jelly
@@ -23,10 +23,11 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-  <f:entry title="${%Job Weight}" field="weight">
+  <f:radioBlock name="weightMode" value="none" title="${%Specify Job Weight Manually}" checked="${instance.allExecutorsEnabled == false}" help="${descriptor.getHelpFile('weight')}">
+    <f:entry title="${%Job Weight}" field="weight">
     <f:textbox default="1" />
-  </f:entry>
-  <f:entry title="${%Use All Executors}" field="allExecutorsEnabled">
-    <f:checkbox/>
-  </f:entry>
+    </f:entry>
+   </f:radioBlock>
+   <f:radioBlock name="weightMode" value="none" title="${%Set Job Weight To All Executors}" checked="${instance.allExecutorsEnabled == true}" help="${descriptor.getHelpFile('allExecutorsEnabled')}">
+  </f:radioBlock>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/heavy_job/HeavyJobProperty/config.jelly
+++ b/src/main/resources/hudson/plugins/heavy_job/HeavyJobProperty/config.jelly
@@ -23,11 +23,14 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-  <f:radioBlock name="weightMode" value="none" title="${%Specify Job Weight Manually}" checked="${instance.allExecutorsEnabled == false}" help="${descriptor.getHelpFile('weight')}">
+  <f:radioBlock name="weightMode" value="none" title="${%Specify Job Weight Manually}" checked="${instance.allExecutorsEnabled == false}" inline="true">
     <f:entry title="${%Job Weight}" field="weight">
-    <f:textbox default="1" />
+     <f:textbox default="1" />
     </f:entry>
    </f:radioBlock>
-   <f:radioBlock name="weightMode" value="none" title="${%Set Job Weight To All Executors}" checked="${instance.allExecutorsEnabled == true}" help="${descriptor.getHelpFile('allExecutorsEnabled')}">
+  <f:radioBlock name="weightMode" value="none" title="${%Set Job Weight To All Executors}" checked="${instance.allExecutorsEnabled == true}" inline="true">
+   <f:entry title="${%Use All Executors}" field="allExecutorsEnabled">
+    <f:checkbox/>
+   </f:entry>
   </f:radioBlock>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/heavy_job/HeavyJobProperty/config.jelly
+++ b/src/main/resources/hudson/plugins/heavy_job/HeavyJobProperty/config.jelly
@@ -23,14 +23,10 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
-  <f:radioBlock name="weightMode" value="none" title="${%Specify Job Weight Manually}" checked="${instance.allExecutorsEnabled == false}" inline="true">
-    <f:entry title="${%Job Weight}" field="weight">
+   <f:entry title="${%Job Weight}" field="weight">
      <f:textbox default="1" />
     </f:entry>
-   </f:radioBlock>
-  <f:radioBlock name="weightMode" value="none" title="${%Set Job Weight To All Executors}" checked="${instance.allExecutorsEnabled == true}" inline="true">
    <f:entry title="${%Use All Executors}" field="allExecutorsEnabled">
     <f:checkbox/>
    </f:entry>
-  </f:radioBlock>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/heavy_job/HeavyJobProperty/help-allExecutorsEnabled.html
+++ b/src/main/resources/hudson/plugins/heavy_job/HeavyJobProperty/help-allExecutorsEnabled.html
@@ -1,0 +1,3 @@
+<div>
+    This option will use all available executors on the node it runs on. If there are builds currently running on the node, the job will wait.
+</div>

--- a/src/main/resources/hudson/plugins/heavy_job/HeavyJobProperty/help-allExecutorsEnabled.html
+++ b/src/main/resources/hudson/plugins/heavy_job/HeavyJobProperty/help-allExecutorsEnabled.html
@@ -1,3 +1,5 @@
 <div>
-    This option will force the build to consume all executors on the node it runs on. If there are builds currently running on the node, the job will wait.
+<p>This option will force the build to consume all executors on the node it runs on. If there are builds currently running on the node, the job will wait.<p>
+
+<p><b>NOTE</b>:The build must be restricted to the self label (node name) or master. All other labels are defaulted to the Job Weight set above. This plugin also supports <a href="https://wiki.jenkins-ci.org/display/JENKINS/NodeLabel+Parameter+Plugin">NodeLabel Parameter Plugin</a>.</p>
 </div>

--- a/src/main/resources/hudson/plugins/heavy_job/HeavyJobProperty/help-allExecutorsEnabled.html
+++ b/src/main/resources/hudson/plugins/heavy_job/HeavyJobProperty/help-allExecutorsEnabled.html
@@ -1,3 +1,3 @@
 <div>
-    This option will use all available executors on the node it runs on. If there are builds currently running on the node, the job will wait.
+    This option will force the build to consume all executors on the node it runs on. If there are builds currently running on the node, the job will wait.
 </div>


### PR DESCRIPTION
Proposing a small feature that will dynamically set weight to the number of executors. Example: I wanted to be able to use a templated build job that can run on any node, with any number of executors. When this particular job builds it can be on the only thing building as it does cleanup that would cause any other build to fail. This plug in worked great, until I had nodes with different number of executors. Take a look, let me know if anything needs correcting.
